### PR TITLE
Allow client to provide their own metadata

### DIFF
--- a/Library/Sources/SCAssetExportSession.h
+++ b/Library/Sources/SCAssetExportSession.h
@@ -108,4 +108,7 @@
  */
 - (void)exportAsynchronouslyWithCompletionHandler:(void(^__nullable)(void))completionHandler;
 
+- (void)exportAsynchronouslyWithCompletionHandler:(void(^__nullable)(void))completionHandler
+                                         metadata:(NSArray<AVMutableMetadataItem *> *__nonnull)metadata;
+
 @end

--- a/Library/Sources/SCAssetExportSession.m
+++ b/Library/Sources/SCAssetExportSession.m
@@ -656,6 +656,12 @@ static CGContextRef SCCreateContextFromPixelBuffer(CVPixelBufferRef pixelBuffer)
 }
 
 - (void)exportAsynchronouslyWithCompletionHandler:(void (^)(void))completionHandler {
+    [self exportAsynchronouslyWithCompletionHandler:completionHandler
+                                           metadata:[SCRecorderTools assetWriterMetadata]];
+}
+
+- (void)exportAsynchronouslyWithCompletionHandler:(void (^)(void))completionHandler
+                                         metadata:(NSArray<AVMutableMetadataItem *> *)metadata {
     _cancelled = NO;
     _nextAllowedVideoFrame = kCMTimeZero;
     NSError *error = nil;
@@ -664,7 +670,7 @@ static CGContextRef SCCreateContextFromPixelBuffer(CVPixelBufferRef pixelBuffer)
     
     _writer = [AVAssetWriter assetWriterWithURL:self.outputUrl fileType:self.outputFileType error:&error];
     _writer.shouldOptimizeForNetworkUse = _shouldOptimizeForNetworkUse;
-    _writer.metadata = [SCRecorderTools assetWriterMetadata];
+    _writer.metadata = metadata;
 
     EnsureSuccess(error, completionHandler);
     


### PR DESCRIPTION
We've been creating faulty video shouts for some time, and sharing for such files to others apps (photos, tik tok, etc) doesn't work. I found a way to "fix" it, and the client won't be uploading faulty files to the server anymore. However, the server already has quite a few files uploaded. Transcoding  the file on the client side fixes the problem, but I can't explain what data transcoding removes, so the files become valid.

However, there's a catch. The iOS client is the only source of faulty files, and ideally we shouldn't do transcoding for good files since it leads to quality loss. I want to write the app version in the file metadata, so we will be able to say whether the file we're dealing with is faulty or not. It will help us to make the decision whether we should apply transcoding or not.